### PR TITLE
Update INSTALLATION.md for building on Fedora for Plasma 6

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -12,7 +12,7 @@ sudo apt install g++ extra-cmake-modules qt6-base-dev qt6-declarative-dev libkf6
 ```
 - Fedora:
 ```
-sudo dnf install extra-cmake-modules qt5-qtdeclarative-devel kf5-plasma-devel kf5-kdeclarative-devel kf5-kconfigwidgets-devel kf5-ki18n-devel kdecoration-devel
+sudo dnf install extra-cmake-modules qt6-qtdeclarative-devel kf6-plasma-devel kf6-kdeclarative-devel kf6-kconfigwidgets-devel kf6-ki18n-devel kdecoration-devel kf6-ksvg-devel kf6-kcmutils-devel kwin-devel
 ```
 - Arch:
 ```


### PR DESCRIPTION
This bumps up KDE packages to Plasma 6 and adds three needed dependencies. Would also fix https://github.com/moodyhunter/applet-window-buttons6/issues/19 https://github.com/moodyhunter/applet-window-buttons6/issues/28