### PR TITLE
Plasma 6.6 Compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(applet_windowbuttons)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 set(VERSION 0.12.0)
 set(AUTHOR "Michail Vourlakos")
 set(EMAIL "mvourlakos@gmail.com")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,6 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(applet_windowbuttons)
 
 set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 set(VERSION 0.12.0)
 set(AUTHOR "Michail Vourlakos")
 set(EMAIL "mvourlakos@gmail.com")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Window Buttons Applet
 
-This is a Plasma 5 applet that shows window buttons in your panels. This plasmoid is coming from [Latte land](https://phabricator.kde.org/source/latte-dock/repository/master/) but it can also support Plasma panels.
+This is a Plasma 6 applet that shows window buttons in your panels. This plasmoid is coming from [Latte land](https://phabricator.kde.org/source/latte-dock/repository/master/) but it can also support Plasma panels.
 
 <p align="center">
 <img src="https://i.imgur.com/4FItfte.gif" width="580"><br/>
@@ -24,14 +24,14 @@ This is a Plasma 5 applet that shows window buttons in your panels. This plasmoi
 
 # Requires
 
-- Qt >= 5.9
-- KF5 >= 5.38
-- Plasma >= 5.23.2
-- KDecoration2 >= 5.23
+- Qt >= 6.6.0
+- KF6 >= 5.246.0
+- Plasma >= 5.90 (Plasma 6)
+- KDecoration3 >= 6.2.90
 
 **Qt elements**: Gui Qml Quick
 
-**KF5 elements**: CoreAddons Declarative Plasma PlasmaQuick extra-cmake-modules
+**KF6 elements**: CoreAddons Config Declarative Package Svg
 
 
 # Install

--- a/libappletdecoration/decorationsmodel.cpp
+++ b/libappletdecoration/decorationsmodel.cpp
@@ -28,6 +28,7 @@ Q_LOGGING_CATEGORY(decorations_model, "DecorationsModel");
 static const QString s_defaultPlugin = QStringLiteral("org.kde.breeze");
 static const QString s_defaultTheme;
 static const QString s_auroraePlugin = QStringLiteral("org.kde.kwin.aurorae");
+static const QString s_auroraePluginV2 = QStringLiteral("org.kde.kwin.aurorae.v2");
 static const QString s_auroraeSvgTheme = QStringLiteral("__aurorae__svg__");
 
 static const QString s_kwinrc = QStringLiteral("kwinrc");
@@ -178,7 +179,7 @@ void DecorationsModel::init()
                 data.themeName = t.themeName();
                 data.visibleName = t.visibleName();
 
-                if (data.pluginName == s_auroraePlugin && data.themeName.startsWith(s_auroraeSvgTheme))
+                if ((data.pluginName == s_auroraePlugin || data.pluginName == s_auroraePluginV2) && data.themeName.startsWith(s_auroraeSvgTheme))
                     data.isAuroraeTheme = true;
 
                 qCInfo(decorations_model) << "Adding theme" << data.visibleName << "from" << data.pluginName;

--- a/package/contents/ui/config/ColorsComboBox.qml
+++ b/package/contents/ui/config/ColorsComboBox.qml
@@ -13,6 +13,46 @@ import QtQuick.Layouts
 ComboBox {
     id: combobox
 
+    function fileAt(row) {
+        if (row < 0)
+            return "";
+
+        return combobox.model.data(combobox.model.index(row, 0), Qt.UserRole + 4);
+    }
+
+    function backgroundColorAt(row) {
+        if (row < 0)
+            return "transparent";
+
+        return combobox.model.data(combobox.model.index(row, 0), Qt.UserRole + 5);
+    }
+
+    function textColorAt(row) {
+        if (row < 0)
+            return palette.text;
+
+        return combobox.model.data(combobox.model.index(row, 0), Qt.UserRole + 6);
+    }
+
+    function displayAt(row) {
+        if (row < 0)
+            return "";
+
+        return combobox.model.data(combobox.model.index(row, 0), Qt.DisplayRole);
+    }
+
+    function applySelection(row) {
+        if (row < 0)
+            return;
+
+        selectedScheme = combobox.fileAt(row);
+    }
+
+    onActivated: {
+        combobox.applySelection(combobox.currentIndex);
+    }
+    displayText: combobox.displayAt(combobox.currentIndex)
+
     Connections {
         function onClosed() {
             root.forceActiveFocus();
@@ -24,10 +64,12 @@ ComboBox {
     delegate: MouseArea {
         width: combobox.width
         height: combobox.height
+        implicitHeight: combobox.height
+        implicitWidth: combobox.width
         hoverEnabled: true
         onClicked: {
             combobox.currentIndex = index;
-            selectedScheme = model.file;
+            combobox.applySelection(index);
             combobox.popup.close();
         }
 
@@ -56,12 +98,12 @@ ComboBox {
                     Layout.leftMargin: 2
                     width: 1.25 * label.height
                     height: label.height
-                    opacity: ((file == "kdeglobals") || (file == "_plasmatheme_")) ? 0 : 1
+                    opacity: ((combobox.fileAt(index) == "kdeglobals") || (combobox.fileAt(index) == "_plasmatheme_")) ? 0 : 1
 
                     Rectangle {
                         width: height
                         height: 0.75 * label.height
-                        color: backgroundColor
+                        color: combobox.backgroundColorAt(index)
                         border.width: 1
                         border.color: containsMouse || (combobox.currentIndex === index) ? palette.highlightedText : palette.text
 
@@ -70,7 +112,7 @@ ComboBox {
                             anchors.verticalCenter: parent.bottom
                             width: parent.width
                             height: parent.height
-                            color: textColor
+                            color: combobox.textColorAt(index)
                             border.width: parent.border.width
                             border.color: parent.border.color
                         }
@@ -82,7 +124,7 @@ ComboBox {
                 Label {
                     id: label
 
-                    text: display
+                    text: combobox.displayAt(index)
                     color: containsMouse ? palette.highlightedText : palette.text
                 }
 


### PR DESCRIPTION
Fixes #30 

> [!WARNING]
> Disclaimer:
> I don't have any experience with Plasma applets and did this using GPT 5.3 Codex
> So I'd appreciate if someone could review this

Both dropdowns were broken

<img width="350" height="76" alt="image" src="https://github.com/user-attachments/assets/c19ae8f3-4fe6-40e7-8c6f-9d8f331588a5" />
<img width="359" height="46" alt="image" src="https://github.com/user-attachments/assets/012b21e6-aa95-4ae0-8f98-ce10e41e12e0" />

Now working again

<img width="376" height="257" alt="image" src="https://github.com/user-attachments/assets/f6b53e34-ddb4-4c87-9732-b83d086a9183" />
<img width="376" height="257" alt="image" src="https://github.com/user-attachments/assets/30ec46af-cb36-4003-ac86-18eee1561597" />

I have a modified copy of the `Breeze Dark` color scheme saved as `Breeze Dark Low Contrast` and noticed that it shows `Breeze Dark Low Contrast` twice for the color dropdown. Not sure if this already was an issue before.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/9d9d08e5-55db-4c36-9af3-5cad4bde31c2" />
