### PR TITLE
Plasma 6: track borderless window targets and modernize KDecoration3

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -42,7 +42,7 @@ SpaceAfterTemplateKeyword: false
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpacesInParentheses: false
-Standard: c++17
+Standard: c++20
 StatementMacros: [Q_UNUSED LOG DEBUG]
 # ForEachMacros: [list_foreach]
 TabWidth: 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 ### CHANGELOG
 
+#### Unreleased
+
+* Follow KWin's `HasNoBorder` state dynamically: show panel controls for
+  borderless floating, tiled, and maximized windows, and hide them as soon as a
+  native titlebar is enabled. Always Visible and panel edit mode remain explicit
+  overrides.
+* Prefer active, then maximized, then most-recent borderless targets while
+  preserving the existing fallback target for window state and actions.
+* Require Plasma 6.4 or newer for the Task Manager `HasNoBorder` role.
+* Fix top-panel/global-menu behavior for borderless maximized windows: panel
+  buttons now target the maximized window on the current screen even when a
+  floating helper/dialog is focused above it.
+* Add `MaximizedWindowExists` visibility mode and expose it as "Maximized window
+  is shown" in Behavior settings.
+* Treat the old "Active window is maximized" visibility mode as a compatibility
+  alias for the maximized-window behavior.
+* Preserve upstream fallback behavior by targeting the active window when no
+  maximized window exists on the current screen.
+* Evaluate inactive button state against the represented maximized window
+  instead of the focused floating window.
+* Keep the represented task as explicit state so focus, minimize, maximize, and
+  stacking changes update visibility, button actions, and inactive colors
+  consistently.
+* Treat full-decoration damage from KDecoration as requiring a button repaint,
+  fixing stale Breeze active/inactive colors that only refreshed after hover.
+* Distinguish special out-of-task-model focus, such as Yakuake, from normal
+  floating windows: special focus makes buttons inactive and non-clickable,
+  while tracked floating focus keeps them usable but dimmed.
+* Recreate decoration buttons when the represented target window changes, so
+  Breeze refreshes the maximize/restore glyph even when the maximized state
+  remains true across the target switch.
+* Fix stale pointer state by forwarding corrected release/hover coordinates to
+  KDecoration.
+* Use Qt 6 input-event constructors for synthetic button events while preserving
+  KDecoration-local positions and the original pointer device.
+* Build with C++20 directly, matching current KDecoration3 requirements.
+* Update package metadata and requirements for Plasma 6/KDecoration3,
+  and remove noisy runtime debug logging from QML/C++ paths.
+* Fix bridge signal cleanup and decoration plugin metadata validation found
+  during the package audit.
+* Dim controls for active floating-only sessions when no maximized window is
+  represented, while keeping them clickable, and hard-inactivate them when focus
+  is outside the task model such as Yakuake.
+* Make "At least one window is shown" depend on any non-minimized tracked window,
+  not only the active or maximized target, while still using the best shown
+  window as the disabled fallback target when focus is outside the task model.
+* Add optional custom slide animation settings: keep the upstream 250 ms
+  accelerated slide as the default, or enable custom timing with duration and
+  acceleration strength controls in Behavior settings.
+
 #### Version 0.11.0
 
 * support Plasma 5.24 way of discovering themes from theme engines

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(applet_windowbuttons)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(VERSION 0.16.0)
+set(VERSION 0.12.0)
 set(AUTHOR "Michail Vourlakos")
 set(EMAIL "mvourlakos@gmail.com")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,27 +3,29 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(applet_windowbuttons)
 
-set(CMAKE_CXX_STANDARD 14)
-set(VERSION 0.12.0)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(VERSION 0.16.0)
 set(AUTHOR "Michail Vourlakos")
 set(EMAIL "mvourlakos@gmail.com")
 
 set(QT_MIN_VERSION "6.6.0")
-set(KF6_MIN_VERSION "5.246.0")
-set(KDecoration3_MIN_VERSION "6.2.90")
+set(KF6_MIN_VERSION "6.0.0")
+set(KDecoration3_MIN_VERSION "6.3.0")
 
 find_package(ECM ${KF6_MIN_VERSION} REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
 
-find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED NO_MODULE COMPONENTS DBus Gui Qml Quick)
-find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS CoreAddons Config Declarative Package Svg)
-find_package(Plasma "5.90" REQUIRED)
-find_package(KDecoration3 ${KDecoration3_MIN_VERSION} REQUIRED)
-
+include(KDEInstallDirs)
+include(KDECMakeSettings)
 include(ECMFindQmlModule)
 include(CheckIncludeFiles)
-include(KDECMakeSettings)
-include(KDEInstallDirs)
+
+find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED NO_MODULE COMPONENTS DBus Gui Qml Quick)
+find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS CoreAddons Config Declarative Package Svg)
+find_package(Plasma "6.4" REQUIRED)
+find_package(KDecoration3 ${KDecoration3_MIN_VERSION} REQUIRED)
 
 set(KDecoration3_VERSION_MAJOR ${KDecoration3_VERSION_MAJOR})
 set(KDecoration3_VERSION_MINOR ${KDecoration3_VERSION_MINOR})

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,41 +1,38 @@
-Installation
-============
+# Installation
 
-## Building from Source
-The provided `install.sh` script will build everything and install it for you. Before running the installation script you have to install the dependencies needed for compiling.
+## Building from source
 
-### Build Dependencies
+Install the Plasma 6 / KDecoration3 development dependencies first. Plasma 6.4
+or newer is required for the Task Manager `HasNoBorder` role used to follow
+native-titlebar changes.
 
-- Ubuntu:
-```
-sudo apt install g++ extra-cmake-modules qt6-base-dev qt6-declarative-dev libkf6declarative-dev libkf6plasma-dev kf6-ksvg-dev libkdecorations2-dev gettext
-```
-- Fedora:
-```
-sudo dnf install extra-cmake-modules qt5-qtdeclarative-devel kf5-plasma-devel kf5-kdeclarative-devel kf5-kconfigwidgets-devel kf5-ki18n-devel kdecoration-devel
-```
-- Arch:
-```
+### Arch
+
+```bash
 sudo pacman -Syu
-sudo pacman -S gcc extra-cmake-modules plasma-framework gettext kdecoration
+sudo pacman -S base-devel cmake extra-cmake-modules qt6-base qt6-declarative kcoreaddons kconfig kdecoration ksvg libplasma plasma-workspace
 ```
 
-### Building and Installing
-Once you have installed the dependencies listed above you can execute the build and install script:
+### Fedora
 
-```
-sh install.sh
-```
+Package names vary by Fedora/KDE spin, but the required development families are
+Qt 6, KF6, Plasma 6, KDecoration3, CMake, and ECM:
 
-## Prebuilt Binaries
-
-- Ubuntu: You can install via a PPA on Ubuntu 18.04 (Bionic) or later including KDE Neon.
-```
-sudo add-apt-repository ppa:krisives/applet-window-buttons
-sudo apt install applet-window-buttons
+```bash
+sudo dnf install gcc-c++ cmake extra-cmake-modules qt6-qtbase-devel qt6-qtdeclarative-devel kf6-kcoreaddons-devel kf6-kconfig-devel kf6-ksvg-devel plasma-workspace-devel kdecoration-devel
 ```
 
-- openSUSE: install the package from the official repo
-```
-sudo zypper in applet-window-buttons
+### Ubuntu / KDE neon
+
+KDecoration3 packaging names vary across Ubuntu releases. Use KDE neon or a
+Plasma 6-capable Ubuntu release and install the Qt 6, KF6, Plasma 6, and
+KDecoration3 development packages available for that release.
+
+## Building and installing
+
+```bash
+cmake -B build -S .
+cmake --build build
+sudo cmake --install build
+systemctl --user restart plasma-plasmashell.service
 ```

--- a/README.md
+++ b/README.md
@@ -1,39 +1,115 @@
 # Window Buttons Applet
 
-This is a Plasma 5 applet that shows window buttons in your panels. This plasmoid is coming from [Latte land](https://phabricator.kde.org/source/latte-dock/repository/master/) but it can also support Plasma panels.
+This Plasma 6 applet provides window controls in a Plasma panel. It is intended
+for global-menu and top-panel layouts where the panel can act as the titlebar for
+borderless windows.
 
-<p align="center">
-<img src="https://i.imgur.com/4FItfte.gif" width="580"><br/>
-<i>slide in/out animation</i>
-</p>
+## Window targeting and titlebar behavior
 
-<p align="center">
-<img src="https://i.imgur.com/70qeMME.png" width="580"><br/>
-<i>Breeze decoration</i>
-</p>
+The applet keeps the existing Plasma package id (`org.kde.windowbuttons`) and
+tracks the window represented by its controls independently from global focus.
 
-<p align="center">
-<img src="https://i.imgur.com/uEen6P0.png" width="580"><br/>
-<i>BreezeEnhanced decoration</i>
-</p>
+## Fixed problem
 
-<p align="center">
-<img src="https://i.imgur.com/Zz20RXC.png" width="580"><br/>
-<i>Settings window</i>
-</p>
+Tying both visibility and button actions only to the active window breaks a
+top-panel workflow:
 
-# Requires
+1. A maximized, borderless window is visually represented by the top panel.
+2. A small floating window, dialog, picker, or helper gets focus above it.
+3. The panel still looks like the maximized window's titlebar.
+4. Pressing the panel close/maximize/minimize buttons unexpectedly affects the
+   focused floating window instead of the maximized window behind it.
 
-- Qt >= 5.9
-- KF5 >= 5.38
-- Plasma >= 5.23.2
-- KDecoration2 >= 5.23
+The applet makes the panel buttons target the maximized window on the current
+screen, because that is the window the panel visually represents. Focus is only
+used as a fallback when no maximized window exists.
 
-**Qt elements**: Gui Qml Quick
+Changes:
 
-**KF5 elements**: CoreAddons Declarative Plasma PlasmaQuick extra-cmake-modules
+- Outside Always Visible and panel edit mode, controls are shown exactly when the
+  represented window has KWin's `HasNoBorder` state. Toggling the native titlebar
+  with Meta+B therefore updates the panel immediately for floating, tiled, and
+  maximized windows, without duplicate controls.
+- Borderless targets are preferred in this order: active borderless, maximized
+  borderless, then most recently activated/stacked borderless. This preserves
+  the maximized-window target behind a focused titled helper while also
+  supporting borderless floating and tiled windows.
+- Window button actions prefer the maximized window on the current screen. If a
+  floating dialog or helper window is focused above a maximized window, the
+  panel buttons still operate on the maximized window they visually represent.
+- If no maximized window exists on that screen, actions fall back to the active
+  window, preserving the useful upstream behavior for normal/floating sessions.
+- The old "Active window is maximized" behavior is treated as a compatibility
+  alias for the maximized-window behavior, because tying panel titlebar
+  visibility to focus is misleading when floating windows overlap maximized
+  windows.
+- A real `MaximizedWindowExists` visibility mode is added and exposed in the
+  Behavior settings as "Maximized window is shown".
+- Maximized-window detection uses Plasma's `TaskManager.TasksModel` after its
+  existing screen, virtual desktop, and activity filters. With "Show only for
+  windows in current screen" enabled, visibility and actions are screen-local.
+- "Draw buttons inactive state when needed" is evaluated against the window
+  represented by the panel buttons, not whichever floating window currently has
+  focus. If the target window is inactive, the panel buttons use inactive
+  decoration colors;
+  when that target window is active, they use active colors.
+- If focus moves to a special window outside Plasma's task model, such as
+  Yakuake, the represented window buttons become truly inactive and clicks do
+  nothing. If focus moves to a normal tracked floating window, the represented
+  buttons stay usable but are dimmed to show that their target is not focused.
+- Button release and hover events are forwarded to KDecoration with corrected
+  coordinates, avoiding stale pointer state caused by mismatched event geometry.
+- Synthetic Qt input events use Qt 6 constructors while keeping
+  `event->position()` in KDecoration's local coordinate system and preserving the
+  originating pointer device.
+- Decoration buttons are recreated when the represented target window changes,
+  which keeps Breeze's internal maximize/restore `checked` state synchronized
+  even when both the old and new targets are maximized.
 
+The goal is to provide predictable defaults for Plasma setups where borderless
+windows use the top panel for their window controls.
 
-# Install
+## Plasma 6 / KDecoration3 compatibility
 
-You can execute `sh install.sh` in the root directory as long as you have installed the previous mentioned development packages. For more details please read [INSTALLATION.md](/INSTALLATION.md)
+The current code targets Plasma 6 and KDecoration3. Plasma 6.3 introduced the
+KDecoration3 API break so server-side decorations can handle fractional scaling
+with floating-point geometry. The code intentionally builds against
+KDecoration3 rather than carrying KDecoration2 compatibility shims.
+
+Minimum build/runtime expectations:
+
+- Qt >= 6.6
+- KDE Frameworks >= 6.0
+- Plasma >= 6.4 (for the Task Manager `HasNoBorder` role)
+- KDecoration3 >= 6.3
+- CMake >= 3.20
+- C++20 compiler
+
+The native button bridge uses KDecoration3 `DecorationButton` and
+`DecoratedWindow` state, including the button `checked` state used by Breeze for
+maximize/restore and on-all-desktops glyphs. When changing this area, test both
+Breeze plugin buttons and Aurorae buttons because they use different rendering
+paths.
+
+## Install from source
+
+```bash
+cmake -B build -S .
+cmake --build build
+sudo cmake --install build
+systemctl --user restart plasma-plasmashell.service
+```
+
+Avoid injecting a rebuilt native QML module into a running plasmashell through a
+local import override. For native plugin experiments, install a normal package
+or use an isolated Plasma/plasmoid test session.
+
+## Audit notes
+
+- Keep the code aligned with KDE's KDecoration3 direction: avoid KDecoration2
+  compatibility paths and prefer `QRectF`/floating geometry APIs where available.
+- Runtime debug logging should stay out of normal builds; use temporary local
+  instrumentation for diagnosis and remove it before committing.
+- Treat `TaskManager.TasksModel` state as asynchronous. Prefer small,
+  observable UI refreshes over stale task-pointer caches when decoration state
+  changes.

--- a/libappletdecoration/CMakeLists.txt
+++ b/libappletdecoration/CMakeLists.txt
@@ -1,14 +1,11 @@
 # SPDX-FileCopyrightText: 2018 Michail Vourlakos <mvourlakos@gmail.com>
 # SPDX-License-Identifier: GPL-2.0-or-later
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
-set(QT_MIN_VERSION "6.6.0")
-set(KF6_MIN_VERSION "6.0.0")
-
-find_package(ECM 0.0.11 REQUIRED NO_MODULE)
+find_package(ECM ${KF6_MIN_VERSION} REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
 
-set(kwin_xml /usr/${KDE_INSTALL_DBUSINTERFACEDIR}/org.kde.KWin.xml)
+set(kwin_xml "${KDE_INSTALL_FULL_DBUSINTERFACEDIR}/org.kde.KWin.xml")
 message(STATUS "KWIN_XML Path : ${kwin_xml}")
 set(KWinConfig_SRCS)
 qt_add_dbus_interface(KWinConfig_SRCS ${kwin_xml} kwin_interface )
@@ -39,7 +36,7 @@ add_library(appletdecorationplugin SHARED ${appletdecoration_SRCS})
 
 find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED Quick DBus Widgets)
 find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS CoreAddons I18n Service ConfigWidgets KCMUtils)
-find_package(KDecoration3 REQUIRED)
+find_package(KDecoration3 ${KDecoration3_MIN_VERSION} REQUIRED)
 
 target_link_libraries(appletdecorationplugin
     Qt6::Core

--- a/libappletdecoration/auroraetheme.cpp
+++ b/libappletdecoration/auroraetheme.cpp
@@ -19,6 +19,8 @@
 #include <QFileInfo>
 #include <QRgb>
 
+using namespace Qt::StringLiterals;
+
 static const QString s_auroraeSvgTheme = QStringLiteral("__aurorae__svg__");
 static const QString s_auroraerc = QStringLiteral("auroraerc");
 static int i_buttonSizeStep = 4;
@@ -174,8 +176,8 @@ void AuroraeTheme::loadSettings()
 
     KSharedConfigPtr rcPtr = KSharedConfig::openConfig(rc);
 
-    const KConfigGroup generalGroup = KConfigGroup(rcPtr, u"General"_qs);
-    const KConfigGroup layoutGroup = KConfigGroup(rcPtr, u"Layout"_qs);
+    const KConfigGroup generalGroup = KConfigGroup(rcPtr, u"General"_s);
+    const KConfigGroup layoutGroup = KConfigGroup(rcPtr, u"Layout"_s);
 
     m_duration = generalGroup.readEntry("Animation", 0);
     m_buttonWidth = layoutGroup.readEntry("ButtonWidth", 24);
@@ -206,7 +208,7 @@ void AuroraeTheme::parseThemeImages()
 
     if (!QFileInfo(origBackgroundFilePath).exists())
     {
-        qDebug() << "Aurorare decoration file was not found for theme: " << m_themeName;
+        qWarning() << "Aurorae decoration file was not found for theme:" << m_themeName;
         return;
     }
 

--- a/libappletdecoration/decorationpalette.cpp
+++ b/libappletdecoration/decorationpalette.cpp
@@ -99,7 +99,7 @@ void DecorationPalette::update()
 
     if (!wmConfig.exists() && !m_colorScheme.endsWith(QStringLiteral("/kdeglobals")))
     {
-        qDebug() << "Invalid color scheme" << m_colorScheme << "lacks WM group";
+        qWarning() << "Invalid color scheme" << m_colorScheme << "lacks WM group";
         return;
     }
 

--- a/libappletdecoration/environment.cpp
+++ b/libappletdecoration/environment.cpp
@@ -8,7 +8,6 @@
 
 #include "environment.h"
 
-#include <QDebug>
 #include <QProcess>
 #include <plasma_version.h>
 
@@ -16,10 +15,7 @@ Environment::Environment(QObject *parent) : QObject(parent)
 {
 }
 
-Environment::~Environment()
-{
-    qDebug() << staticMetaObject.className() << "destructed";
-}
+Environment::~Environment() = default;
 
 uint Environment::frameworksVersion() const
 {
@@ -53,7 +49,6 @@ uint Environment::identifyPlasmaDesktopVersion()
 
     if (stringSplit.count() >= 2)
     {
-        qDebug() << " /////////////////////////";
         QString cleanVersionString = stringSplit[1].remove("\n");
         QStringList plasmaDesktopVersionParts = cleanVersionString.split(".");
 
@@ -68,16 +63,9 @@ uint Environment::identifyPlasmaDesktopVersion()
 
                 uint desktopVersion = makeVersion(maj, min, rel);
 
-                QString message("Plasma Desktop version:  " + QString::number(maj) + "." + QString::number(min) + "." + QString::number(rel) + " (" +
-                                QString::number(desktopVersion) + ")");
-                qDebug() << message;
-                qDebug() << " /////////////////////////";
-
                 return desktopVersion;
             }
         }
-
-        qDebug() << " /////////////////////////";
     }
 
     return 0;

--- a/libappletdecoration/previewbridge.cpp
+++ b/libappletdecoration/previewbridge.cpp
@@ -65,7 +65,6 @@ void PreviewBridge::setPlugin(const QString &plugin)
         return;
 
     m_plugin = plugin;
-    qDebug() << "Plugin changed to: " << m_plugin;
     emit pluginChanged();
 }
 
@@ -95,16 +94,17 @@ void PreviewBridge::createFactory()
     if (m_plugin.isNull())
     {
         setValid(false);
-        qDebug() << "Plugin not set";
         return;
     }
 
-    qDebug() << "Searching for plugins: " << m_plugin;
-
     const auto plugins = KPluginMetaData::findPluginById("org.kde.kdecoration3", m_plugin);
+    if (!plugins.isValid())
+    {
+        setValid(false);
+        return;
+    }
 
     m_factory = KPluginFactory::loadFactory(plugins).plugin;
-    qDebug() << "Factory: " << !m_factory.isNull();
     setValid(!m_factory.isNull());
     reconfigure();
 }

--- a/libappletdecoration/previewbutton.cpp
+++ b/libappletdecoration/previewbutton.cpp
@@ -216,7 +216,6 @@ void PreviewButtonItem::setScheme(QString scheme)
     if (m_client)
     {
         m_client->setColorScheme(m_scheme);
-        qDebug() << "buttons scheme update to:" << m_scheme;
     }
 
     emit schemeChanged();
@@ -426,7 +425,7 @@ void PreviewButtonItem::onButtonDamaged()
 
 void PreviewButtonItem::onDecorationDamaged(const QRegion &region)
 {
-    if (region.intersects(m_visualGeometry))
+    if (region.isEmpty() || region.intersects(m_visualGeometry))
     {
         update();
     }
@@ -463,7 +462,8 @@ void PreviewButtonItem::mousePressEvent(QMouseEvent *event)
 
     //! this a workaround in order to send proper coordinates
     //! that confirm the button visual coordinates
-    QMouseEvent e(event->type(), m_visualGeometry.center(), event->button(), event->buttons(), event->modifiers());
+    const QPointF localPos = m_visualGeometry.center();
+    QMouseEvent e(event->type(), localPos, localPos, event->globalPosition(), event->button(), event->buttons(), event->modifiers(), event->pointingDevice());
 
     QCoreApplication::instance()->sendEvent(m_button, &e);
 }
@@ -479,9 +479,10 @@ void PreviewButtonItem::mouseReleaseEvent(QMouseEvent *event)
 
     //! this a workaround in order to send proper coordinates
     //! that confirm the button visual coordinates
-    QMouseEvent e(event->type(), inItem ? m_visualGeometry.center() : QPoint(-5, -5), event->button(), event->buttons(), event->modifiers());
+    const QPointF localPos = inItem ? m_visualGeometry.center() : QPoint(-5, -5);
+    QMouseEvent e(event->type(), localPos, localPos, event->globalPosition(), event->button(), event->buttons(), event->modifiers(), event->pointingDevice());
 
-    QCoreApplication::instance()->sendEvent(m_button, event);
+    QCoreApplication::instance()->sendEvent(m_button, &e);
 
     if (inItem)
     {
@@ -498,7 +499,8 @@ void PreviewButtonItem::mouseMoveEvent(QMouseEvent *event)
 
     //! this a workaround in order to send proper coordinates
     //! that confirm the button visual coordinates
-    QMouseEvent e(event->type(), m_visualGeometry.center(), event->button(), event->buttons(), event->modifiers());
+    const QPointF localPos = m_visualGeometry.center();
+    QMouseEvent e(event->type(), localPos, localPos, event->globalPosition(), event->button(), event->buttons(), event->modifiers(), event->pointingDevice());
 
     QCoreApplication::instance()->sendEvent(m_button, &e);
 }
@@ -512,8 +514,9 @@ void PreviewButtonItem::hoverEnterEvent(QHoverEvent *event)
 
     //! this a workaround in order to send proper coordinates
     //! that confirm the button visual coordinates
-    QHoverEvent e(event->type(), m_visualGeometry.center(), QPoint(m_visualGeometry.x() + event->position().x(), m_visualGeometry.y() + event->position().y()),
-                  event->modifiers());
+    const QPointF localPos = m_visualGeometry.center();
+    const QPointF oldPos(m_visualGeometry.x() + event->position().x(), m_visualGeometry.y() + event->position().y());
+    QHoverEvent e(event->type(), localPos, event->globalPosition(), oldPos, event->modifiers(), event->pointingDevice());
 
     QCoreApplication::instance()->sendEvent(m_button, &e);
 }
@@ -527,7 +530,8 @@ void PreviewButtonItem::hoverLeaveEvent(QHoverEvent *event)
 
     //! this a workaround in order to send proper coordinates
     //! that confirm the button visual coordinates
-    QHoverEvent e(event->type(), QPoint(-5, -5), m_visualGeometry.center(), event->modifiers());
+    const QPointF localPos(-5, -5);
+    QHoverEvent e(event->type(), localPos, event->globalPosition(), m_visualGeometry.center(), event->modifiers(), event->pointingDevice());
 
     QCoreApplication::instance()->sendEvent(m_button, &e);
 }
@@ -540,19 +544,24 @@ void PreviewButtonItem::hoverMoveEvent(QHoverEvent *event)
     }
 
     QPoint newPos(qBound((double) m_visualGeometry.left(), m_visualGeometry.left() + event->position().x(), (double) m_visualGeometry.right()),
-                  qBound((double) m_visualGeometry.top(), m_visualGeometry.top() + event->position().x(), (double) m_visualGeometry.bottom()));
+                  qBound((double) m_visualGeometry.top(), m_visualGeometry.top() + event->position().y(), (double) m_visualGeometry.bottom()));
 
     QPoint oldPos(qBound((double) m_visualGeometry.left(), m_visualGeometry.left() + event->oldPosF().x(), (double) m_visualGeometry.right()),
-                  qBound((double) m_visualGeometry.top(), m_visualGeometry.top() + event->oldPosF().x(), (double) m_visualGeometry.bottom()));
+                  qBound((double) m_visualGeometry.top(), m_visualGeometry.top() + event->oldPosF().y(), (double) m_visualGeometry.bottom()));
 
     //! this a workaround in order to send proper coordinates
     //! that confirm the button visual coordinates
-    QHoverEvent e(event->type(), newPos, oldPos, event->modifiers());
+    QHoverEvent e(event->type(), newPos, event->globalPosition(), oldPos, event->modifiers(), event->pointingDevice());
 
     QCoreApplication::instance()->sendEvent(m_button, &e);
 }
 
 void PreviewButtonItem::focusOutEvent(QFocusEvent *event)
 {
+    if (!m_button)
+    {
+        return;
+    }
+
     QCoreApplication::instance()->sendEvent(m_button, event);
 }

--- a/libappletdecoration/previewclient.cpp
+++ b/libappletdecoration/previewclient.cpp
@@ -353,12 +353,10 @@ void PreviewClient::setBordersTopEdge(bool enabled)
 void PreviewClient::requestShowToolTip(const QString &text)
 {
     Q_UNUSED(text)
-    // qDebug() << "tooltip show requested with text:" << text;
 }
 
 void PreviewClient::requestHideToolTip()
 {
-    // qDebug() << "tooltip hide requested";
 }
 
 QSizeF PreviewClient::size() const
@@ -379,7 +377,6 @@ void PreviewClient::requestClose()
 
 void PreviewClient::requestContextHelp()
 {
-    qDebug() << "context help requested";
 }
 
 void PreviewClient::requestToggleMaximization(Qt::MouseButtons buttons)

--- a/libappletdecoration/previewshareddecoration.cpp
+++ b/libappletdecoration/previewshareddecoration.cpp
@@ -38,12 +38,15 @@ void SharedDecoration::setBridge(PreviewBridge *bridge)
 
     if (m_bridge)
     {
-        connect(m_bridge, &PreviewBridge::validChanged, this, &SharedDecoration::createDecoration);
+        disconnect(m_bridge, &PreviewBridge::validChanged, this, &SharedDecoration::createDecoration);
     }
 
     m_bridge = bridge;
 
-    connect(m_bridge, &PreviewBridge::validChanged, this, &SharedDecoration::createDecoration);
+    if (m_bridge)
+    {
+        connect(m_bridge, &PreviewBridge::validChanged, this, &SharedDecoration::createDecoration);
+    }
 
     emit bridgeChanged();
 }

--- a/libappletdecoration/schemecolors.cpp
+++ b/libappletdecoration/schemecolors.cpp
@@ -151,7 +151,7 @@ QString SchemeColors::possibleSchemeFile(QString scheme)
         if (QFileInfo(settingsFile).exists())
         {
             KSharedConfigPtr filePtr = KSharedConfig::openConfig(settingsFile);
-            KConfigGroup generalGroup = KConfigGroup(filePtr, u"General"_qs);
+            KConfigGroup generalGroup = KConfigGroup(filePtr, u"General"_s);
             tempScheme = generalGroup.readEntry("ColorScheme", "BreezeLight");
         }
     }
@@ -184,7 +184,7 @@ QString SchemeColors::schemeName(QString originalFile)
     }
 
     KSharedConfigPtr filePtr = KSharedConfig::openConfig(originalFile);
-    KConfigGroup generalGroup = KConfigGroup(filePtr, u"General"_qs);
+    KConfigGroup generalGroup = KConfigGroup(filePtr, u"General"_s);
 
     return generalGroup.readEntry("Name", fileNameNoExt);
 }
@@ -197,11 +197,11 @@ void SchemeColors::updateScheme()
     }
 
     KSharedConfigPtr filePtr = KSharedConfig::openConfig(m_schemeFile);
-    KConfigGroup wmGroup = KConfigGroup(filePtr, u"WM"_qs);
-    KConfigGroup selGroup = KConfigGroup(filePtr, u"Colors:Selection"_qs);
-    KConfigGroup viewGroup = KConfigGroup(filePtr, u"Colors:View"_qs);
+    KConfigGroup wmGroup = KConfigGroup(filePtr, u"WM"_s);
+    KConfigGroup selGroup = KConfigGroup(filePtr, u"Colors:Selection"_s);
+    KConfigGroup viewGroup = KConfigGroup(filePtr, u"Colors:View"_s);
     // KConfigGroup windowGroup = KConfigGroup(filePtr, "Colors:Window");
-    KConfigGroup buttonGroup = KConfigGroup(filePtr, u"Colors:Button"_qs);
+    KConfigGroup buttonGroup = KConfigGroup(filePtr, u"Colors:Button"_s);
 
     if (!m_basedOnPlasmaTheme)
     {

--- a/libappletdecoration/themeextended.cpp
+++ b/libappletdecoration/themeextended.cpp
@@ -15,10 +15,11 @@
 #include <KConfigGroup>
 #include <KDirWatch>
 #include <KSharedConfig>
-#include <QDebug>
 #include <QDir>
 
 #define DEFAULTCOLORSCHEME "default.colors"
+
+using namespace Qt::StringLiterals;
 
 ExtendedTheme::ExtendedTheme(QObject *parent) : QObject(parent)
 {
@@ -52,8 +53,6 @@ void ExtendedTheme::setOriginalSchemeFile(const QString &file)
 
     m_originalSchemePath = file;
 
-    qDebug() << "Window Buttons : plasma theme original colors ::: " << m_originalSchemePath;
-
     updateDefaultScheme();
 
     emit themeChanged();
@@ -85,8 +84,6 @@ void ExtendedTheme::updateDefaultScheme()
     m_colorsScheme = new SchemeColors(this, m_colorsSchemePath, true);
     connect(m_colorsScheme, &SchemeColors::colorsChanged, this, &ExtendedTheme::themeChanged);
 
-    qDebug() << "Window Buttons : plasma theme default colors ::: " << m_colorsSchemePath;
-
     emit colorsChanged();
 }
 
@@ -98,8 +95,8 @@ void ExtendedTheme::updateDefaultSchemeValues()
 
     if (originalPtr && defaultPtr)
     {
-        KConfigGroup normalWindowGroup(originalPtr, u"Colors:Window"_qs);
-        KConfigGroup defaultWMGroup(defaultPtr, u"WM"_qs);
+        KConfigGroup normalWindowGroup(originalPtr, u"Colors:Window"_s);
+        KConfigGroup defaultWMGroup(defaultPtr, u"WM"_s);
 
         defaultWMGroup.writeEntry("activeBackground", normalWindowGroup.readEntry("BackgroundNormal", QColor()));
         defaultWMGroup.writeEntry("activeForeground", normalWindowGroup.readEntry("ForegroundNormal", QColor()));
@@ -120,10 +117,6 @@ void ExtendedTheme::loadThemePaths()
     {
         m_themeWidgetsPath = standardPath("plasma/desktoptheme/default/widgets");
     }
-
-    qDebug() << "Window Buttons : current plasma theme ::: " << m_theme.themeName();
-    qDebug() << "Window Buttons : theme path ::: " << m_themePath;
-    qDebug() << "Window Buttons : theme widgets path ::: " << m_themeWidgetsPath;
 
     //! clear kde connections
     for (auto &c : m_kdeConnections)

--- a/libappletdecoration/types.h
+++ b/libappletdecoration/types.h
@@ -64,7 +64,8 @@ class Types
         AlwaysVisible = 0,
         ActiveWindow,
         ActiveMaximizedWindow,
-        ShownWindowExists
+        ShownWindowExists,
+        MaximizedWindowExists
     };
     Q_ENUM(Visibility)
 

--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -34,6 +34,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
         <choice name="AlwaysVisible" />
         <choice name="ActiveWindow" />
         <choice name="ActiveMaximizedWindow" />
+        <choice name="ShownWindowExists" />
+        <choice name="MaximizedWindowExists" />
       </choices>
       <label>when the applet will be visible</label>
       <default>0</default>
@@ -53,6 +55,22 @@ SPDX-License-Identifier: GPL-2.0-or-later
       </choices>
       <label>when the applet should be hidden how it should behave</label>
       <default>0</default>
+    </entry>
+    <entry name="customSlideAnimation" type="Bool">
+      <default>false</default>
+      <label>use custom slide animation timing instead of the default</label>
+    </entry>
+    <entry name="slideAnimationDuration" type="Int">
+      <default>250</default>
+      <min>50</min>
+      <max>1000</max>
+      <label>slide animation duration in milliseconds</label>
+    </entry>
+    <entry name="slideAnimationAcceleration" type="Int">
+      <default>2</default>
+      <min>0</min>
+      <max>4</max>
+      <label>slide animation acceleration strength, from linear to aggressive</label>
     </entry>
     <entry name="inactiveStateEnabled" type="Bool">
       <default>false</default>

--- a/package/contents/ui/PlasmaTasksModel.qml
+++ b/package/contents/ui/PlasmaTasksModel.qml
@@ -16,37 +16,153 @@ Item {
     id: plasmaTasksItem
 
     property bool filterByScreen: true
-    readonly property bool existsWindowActive: lastActiveTaskItem && tasksRepeater.count > 0 && (root.perScreenActive || lastActiveTaskItem.isActive)
-    readonly property bool existsWindowShown: lastActiveTaskItem && tasksRepeater.count > 0 && !lastActiveTaskItem.isMinimized
-    property Item lastActiveTaskItem: null
+    readonly property bool existsWindowActive: activeTaskItem && tasksRepeater.count > 0 && (root.perScreenActive || activeTaskItem.isActive)
+    readonly property bool existsWindowShown: shownTaskItem && tasksRepeater.count > 0
+    readonly property bool hasTrackedWindow: tasksRepeater.count > 0
+    property bool existsMaximizedWindow: false
+    readonly property bool targetWindowIsActive: targetTaskItem && existsWindowShown && targetTaskItem.isActive
+    readonly property bool hasActiveTask: activeTaskItem && activeTaskItem.isActive
+    readonly property bool focusOutsideTaskModel: hasTrackedWindow && !hasActiveTask && !targetTaskItem
+    readonly property bool targetObscuredByTrackedWindow: targetTaskItem && existsWindowShown && !targetWindowIsActive && hasActiveTask && activeTaskItem !== targetTaskItem
+    readonly property bool activeFloatingWithoutMaximizedTarget: targetTaskItem && existsWindowShown && !existsMaximizedWindow && targetWindowIsActive
+    readonly property Item lastActiveTaskItem: targetTaskItem
+    property Item activeTaskItem: null
+    property Item lastMaximizedTaskItem: null
+    property Item lastBorderlessTaskItem: null
+    property Item shownTaskItem: null
+    property Item targetTaskItem: null
+
+    function bestShownTaskItem() {
+        var bestTask = null;
+
+        for (var i = 0; i < tasksRepeater.count; ++i) {
+            var task = tasksRepeater.itemAt(i);
+
+            if (!task || task.isMinimized)
+                continue;
+
+            if (!bestTask || task.lastActivated > bestTask.lastActivated || (task.lastActivated === bestTask.lastActivated && task.stackingOrder > bestTask.stackingOrder))
+                bestTask = task;
+        }
+
+        return bestTask;
+    }
+
+    function maximizedTaskItem() {
+        var bestTask = null;
+
+        for (var i = 0; i < tasksRepeater.count; ++i) {
+            var task = tasksRepeater.itemAt(i);
+
+            if (!task || !task.isMaximized || task.isMinimized)
+                continue;
+
+            if (!bestTask || task.lastActivated > bestTask.lastActivated || (task.lastActivated === bestTask.lastActivated && task.stackingOrder > bestTask.stackingOrder))
+                bestTask = task;
+        }
+
+        return bestTask;
+    }
+
+    function borderlessTaskItem(maximizedOnly) {
+        var bestTask = null;
+
+        for (var i = 0; i < tasksRepeater.count; ++i) {
+            var task = tasksRepeater.itemAt(i);
+
+            if (!task || !task.hasNoBorder || task.isMinimized || (maximizedOnly && !task.isMaximized))
+                continue;
+
+            if (!bestTask || task.lastActivated > bestTask.lastActivated || (task.lastActivated === bestTask.lastActivated && task.stackingOrder > bestTask.stackingOrder))
+                bestTask = task;
+        }
+
+        return bestTask;
+    }
+
+    function updateWindowState() {
+        shownTaskItem = bestShownTaskItem();
+        lastMaximizedTaskItem = maximizedTaskItem();
+        lastBorderlessTaskItem = borderlessTaskItem(false);
+        existsMaximizedWindow = lastMaximizedTaskItem !== null;
+
+        if (activeTaskItem && activeTaskItem.hasNoBorder && !activeTaskItem.isMinimized) {
+            targetTaskItem = activeTaskItem;
+            return;
+        }
+
+        var borderlessMaximizedTaskItem = borderlessTaskItem(true);
+        if (borderlessMaximizedTaskItem) {
+            targetTaskItem = borderlessMaximizedTaskItem;
+            return;
+        }
+
+        if (lastBorderlessTaskItem) {
+            targetTaskItem = lastBorderlessTaskItem;
+            return;
+        }
+
+        if (activeTaskItem && activeTaskItem.isMaximized && !activeTaskItem.isMinimized) {
+            targetTaskItem = activeTaskItem;
+            return;
+        }
+
+        targetTaskItem = lastMaximizedTaskItem || activeTaskItem || shownTaskItem;
+    }
+
+    function activeTask() {
+        for (var i = 0; i < tasksRepeater.count; ++i) {
+            var task = tasksRepeater.itemAt(i);
+
+            if (task && task.isActive)
+                return task;
+        }
+
+        return null;
+    }
+
+    function actionTargetTaskItem() {
+        updateWindowState();
+        return targetTaskItem;
+    }
 
     function toggleMaximized() {
-        if (lastActiveTaskItem)
-            lastActiveTaskItem.toggleMaximized();
+        var task = actionTargetTaskItem();
+
+        if (task)
+            task.toggleMaximized();
 
     }
 
     function toggleMinimized() {
-        if (lastActiveTaskItem)
-            lastActiveTaskItem.toggleMinimized();
+        var task = actionTargetTaskItem();
+
+        if (task)
+            task.toggleMinimized();
 
     }
 
     function toggleClose() {
-        if (lastActiveTaskItem)
-            lastActiveTaskItem.toggleClose();
+        var task = actionTargetTaskItem();
+
+        if (task)
+            task.toggleClose();
 
     }
 
     function togglePinToAllDesktops() {
-        if (lastActiveTaskItem)
-            lastActiveTaskItem.togglePinToAllDesktops();
+        var task = actionTargetTaskItem();
+
+        if (task)
+            task.togglePinToAllDesktops();
 
     }
 
     function toggleKeepAbove() {
-        if (lastActiveTaskItem)
-            lastActiveTaskItem.toggleKeepAbove();
+        var task = actionTargetTaskItem();
+
+        if (task)
+            task.toggleKeepAbove();
 
     }
 
@@ -86,12 +202,15 @@ Item {
                 readonly property bool isMinimized: IsMinimized === true ? true : false
                 readonly property bool isMaximized: IsMaximized === true ? true : false
                 readonly property bool isActive: IsActive === true ? true : false
+                readonly property bool hasNoBorder: HasNoBorder === true
                 readonly property bool isOnAllDesktops: IsOnAllVirtualDesktops === true ? true : false
                 readonly property bool isKeepAbove: IsKeepAbove === true ? true : false
                 readonly property bool isClosable: IsClosable === true ? true : false
                 readonly property bool isMinimizable: IsMinimizable === true ? true : false
                 readonly property bool isMaximizable: IsMaximizable === true ? true : false
                 readonly property bool isVirtualDesktopsChangeable: IsVirtualDesktopsChangeable === true ? true : false
+                readonly property double lastActivated: LastActivated ? LastActivated : 0
+                readonly property int stackingOrder: StackingOrder ? StackingOrder : 0
 
                 function modelIndex() {
                     return tasksModel.makeModelIndex(index);
@@ -118,14 +237,37 @@ Item {
                 }
 
                 onIsActiveChanged: {
+                    plasmaTasksItem.activeTaskItem = isActive ? task : plasmaTasksItem.activeTask();
+                    plasmaTasksItem.updateWindowState();
+                }
+                onIsMinimizedChanged: plasmaTasksItem.updateWindowState()
+                onIsMaximizedChanged: plasmaTasksItem.updateWindowState()
+                onHasNoBorderChanged: plasmaTasksItem.updateWindowState()
+                onLastActivatedChanged: plasmaTasksItem.updateWindowState()
+                onStackingOrderChanged: plasmaTasksItem.updateWindowState()
+                Component.onCompleted: {
                     if (isActive)
-                        plasmaTasksItem.lastActiveTaskItem = task;
+                        plasmaTasksItem.activeTaskItem = task;
 
+                    plasmaTasksItem.updateWindowState();
                 }
                 Component.onDestruction: {
-                    if (plasmaTasksItem.lastActiveTaskItem === task)
-                        plasmaTasksItem.lastActiveTaskItem = null;
+                    if (plasmaTasksItem.activeTaskItem === task)
+                        plasmaTasksItem.activeTaskItem = null;
 
+                    if (plasmaTasksItem.lastMaximizedTaskItem === task)
+                        plasmaTasksItem.lastMaximizedTaskItem = null;
+
+                    if (plasmaTasksItem.lastBorderlessTaskItem === task)
+                        plasmaTasksItem.lastBorderlessTaskItem = null;
+
+                    if (plasmaTasksItem.shownTaskItem === task)
+                        plasmaTasksItem.shownTaskItem = null;
+
+                    if (plasmaTasksItem.targetTaskItem === task)
+                        plasmaTasksItem.targetTaskItem = null;
+
+                    Qt.callLater(plasmaTasksItem.updateWindowState);
                 }
             }
 

--- a/package/contents/ui/config/ConfigBehavior.qml
+++ b/package/contents/ui/config/ConfigBehavior.qml
@@ -20,11 +20,15 @@ KCM.SimpleKCM {
     property alias cfg_perScreenActive: perScreenActiveChk.checked
     property alias cfg_filterByScreen: filterByScreenChk.checked
     property alias cfg_inactiveStateEnabled: inactiveChk.checked
+    property alias cfg_customSlideAnimation: customSlideAnimationChk.checked
+    property alias cfg_slideAnimationDuration: slideAnimationDurationSpin.value
+    property alias cfg_slideAnimationAcceleration: slideAnimationAccelerationSpin.value
     property alias cfg_borderlessMaximizedWindows: root.borderlessMaximizedWindows
 
     // used as bridge to communicate properly between configuration and ui
     property int visibility
     property int hiddenState
+    readonly property bool customSlideControlsEnabled: customSlideAnimationChk.checked && slideOutBtn.checked && root.visibility !== AppletDecoration.Types.AlwaysVisible
     property bool borderlessMaximizedWindows: kwinConfig.borderlessMaximizedWindows
     property bool initialBorderlessMaximizedWindowsValue: kwinConfig.borderlessMaximizedWindows
 
@@ -78,13 +82,13 @@ KCM.SimpleKCM {
         }
 
         QQC2.RadioButton {
-            id: activeMaximizedBtn
+            id: maximizedWindowBtn
             QQC2.ButtonGroup.group: visibilityBtnGroup
-            text: i18n("Active window is maximized")
-            checked: root.visibility === AppletDecoration.Types.ActiveMaximizedWindow
+            text: i18n("Maximized window is shown")
+            checked: root.visibility === AppletDecoration.Types.ActiveMaximizedWindow || root.visibility === AppletDecoration.Types.MaximizedWindowExists
             onCheckedChanged: {
                 if (checked)
-                    root.visibility = AppletDecoration.Types.ActiveMaximizedWindow;
+                    root.visibility = AppletDecoration.Types.MaximizedWindowExists;
 
             }
         }
@@ -129,6 +133,94 @@ KCM.SimpleKCM {
                 if (checked)
                     root.hiddenState = AppletDecoration.Types.EmptySpace;
 
+            }
+        }
+
+        QQC2.CheckBox {
+            id: customSlideAnimationChk
+            Kirigami.FormData.label: i18n("Slide animation:")
+            text: i18n("Use custom timing")
+            enabled: slideOutBtn.checked && root.visibility !== AppletDecoration.Types.AlwaysVisible
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Duration:")
+            enabled: root.customSlideControlsEnabled
+            opacity: enabled ? 1 : 0.45
+
+            QQC2.Slider {
+                id: slideAnimationDurationSlider
+
+                Layout.fillWidth: true
+                from: 50
+                to: 1000
+                stepSize: 10
+                snapMode: QQC2.Slider.SnapAlways
+                value: slideAnimationDurationSpin.value
+                onMoved: slideAnimationDurationSpin.value = Math.round(value / 10) * 10
+            }
+
+            QQC2.SpinBox {
+                id: slideAnimationDurationSpin
+
+                from: 50
+                to: 1000
+                stepSize: 10
+                textFromValue: function(value) {
+                    return i18n("%1 ms", value);
+                }
+                valueFromText: function(text) {
+                    return parseInt(text);
+                }
+            }
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Acceleration:")
+            enabled: root.customSlideControlsEnabled
+            opacity: enabled ? 1 : 0.45
+
+            QQC2.Slider {
+                id: slideAnimationAccelerationSlider
+
+                Layout.fillWidth: true
+                from: 0
+                to: 4
+                stepSize: 1
+                snapMode: QQC2.Slider.SnapAlways
+                value: slideAnimationAccelerationSpin.value
+                onMoved: slideAnimationAccelerationSpin.value = Math.round(value)
+            }
+
+            QQC2.SpinBox {
+                id: slideAnimationAccelerationSpin
+
+                from: 0
+                to: 4
+                textFromValue: function(value) {
+                    if (value === 0)
+                        return i18n("None");
+                    if (value === 1)
+                        return i18n("Soft");
+                    if (value === 2)
+                        return i18n("Default");
+                    if (value === 3)
+                        return i18n("Fast");
+
+                    return i18n("Aggressive");
+                }
+                valueFromText: function(text) {
+                    if (text === i18n("None"))
+                        return 0;
+                    if (text === i18n("Soft"))
+                        return 1;
+                    if (text === i18n("Default"))
+                        return 2;
+                    if (text === i18n("Fast"))
+                        return 3;
+
+                    return 4;
+                }
             }
         }
 

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -46,10 +46,6 @@ KCM.SimpleKCM {
     property string currentPlugin: root.useCurrent || !selectedDecorationExists ? decorations.currentPlugin : root.selectedPlugin
     property string currentTheme: root.useCurrent || !selectedDecorationExists ? decorations.currentTheme : root.selectedTheme
 
-    onSelectedPluginChanged: {
-        console.log("Selected Plugin CHanged: ", root.selectedPlugin)
-    }
-
     ///START Decoration Items
     AppletDecoration.Bridge {
         id: bridgeItem

--- a/package/contents/ui/config/DecorationsComboBox.qml
+++ b/package/contents/ui/config/DecorationsComboBox.qml
@@ -22,7 +22,6 @@ ComboBox {
         if (index === -1)
             return ;
 
-        console.log(currentTheme, combobox.currentText, combobox.currentValue);
         root.useCurrent = false;
         root.selectedPlugin = combobox.currentValue;
         root.selectedTheme = combobox.currentText;

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -20,24 +20,21 @@ PlasmoidItem {
     property int animatedMinimumWidth: minimumWidth
     property int animatedMinimumHeight: minimumHeight
     property int screen: plasmoid.containment.screen
+    readonly property bool maximizedWindowVisibility: visibility === AppletDecoration.Types.ActiveMaximizedWindow || visibility === AppletDecoration.Types.MaximizedWindowExists
     readonly property bool inEditMode: plasmoid.userConfiguring || plasmoid.containment.corona.editMode
     readonly property bool mustHide: {
         if (visibility === AppletDecoration.Types.AlwaysVisible || inEditMode)
             return false;
 
-        if (visibility === AppletDecoration.Types.ActiveWindow && !existsWindowActive)
-            return true;
-
-        if (visibility === AppletDecoration.Types.ActiveMaximizedWindow && (!isLastActiveWindowMaximized || !existsWindowActive))
-            return true;
-
-        if (visibility === AppletDecoration.Types.ShownWindowExists && !existsWindowShown)
+        if (!lastActiveTaskItem || !existsWindowShown || !isLastActiveWindowBorderless)
             return true;
 
         return false;
     }
     readonly property bool selectedDecorationExists: decorations.decorationExists(plasmoid.configuration.selectedPlugin, plasmoid.configuration.selectedTheme)
     readonly property bool slideAnimationEnabled: ((visibility !== AppletDecoration.Types.AlwaysVisible) && (plasmoid.configuration.hiddenState === AppletDecoration.Types.SlideOut))
+    readonly property int slideAnimationDuration: plasmoid.configuration.customSlideAnimation ? plasmoid.configuration.slideAnimationDuration : 250
+    readonly property int slideAnimationAcceleration: plasmoid.configuration.customSlideAnimation ? plasmoid.configuration.slideAnimationAcceleration : 2
     readonly property bool isEmptySpaceEnabled: plasmoid.configuration.hiddenState === AppletDecoration.Types.EmptySpace
     readonly property int visibility: plasmoid.configuration.visibility
     readonly property bool perScreenActive: plasmoid.configuration.perScreenActive
@@ -84,12 +81,18 @@ PlasmoidItem {
     //! make sure that on startup it will always be shown
     readonly property bool existsWindowActive: (windowInfoLoader.item && windowInfoLoader.item.existsWindowActive)
     readonly property bool existsWindowShown: (windowInfoLoader.item && windowInfoLoader.item.existsWindowShown)
+    readonly property bool existsMaximizedWindow: (windowInfoLoader.item && windowInfoLoader.item.existsMaximizedWindow)
+    readonly property bool blocksInactiveWindowActions: inactiveStateEnabled && windowInfoLoader.item && windowInfoLoader.item.focusOutsideTaskModel
+    readonly property bool dimsInactiveWindowActions: inactiveStateEnabled && windowInfoLoader.item && windowInfoLoader.item.targetObscuredByTrackedWindow
+    readonly property real inactiveDimOpacity: 0.62
     readonly property bool isLastActiveWindowPinned: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.isOnAllDesktops
     readonly property bool isLastActiveWindowMaximized: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.isMaximized
+    readonly property bool isLastActiveWindowActive: windowInfoLoader.item && windowInfoLoader.item.targetWindowIsActive
     readonly property bool isLastActiveWindowKeepAbove: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.isKeepAbove
     readonly property bool isLastActiveWindowClosable: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.isClosable
     readonly property bool isLastActiveWindowMaximizable: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.isMaximizable
     readonly property bool isLastActiveWindowMinimizable: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.isMinimizable
+    readonly property bool isLastActiveWindowBorderless: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.hasNoBorder
     readonly property bool isLastActiveWindowVirtualDesktopsChangeable: lastActiveTaskItem && existsWindowShown && lastActiveTaskItem.isVirtualDesktopsChangeable
     property bool hasDesktopsButton: false
     property bool hasMaximizedButton: false
@@ -114,7 +117,6 @@ PlasmoidItem {
     }
 
     function initializeControlButtonsModel() {
-        console.log("recreating buttons");
         sharedDecorationItem.createDecoration();
         var buttonsList = buttonsStr.split('|');
         ModelTools.initializeControlButtonsModel(buttonsList, tasksPreparedArray, controlButtonsModel, true);
@@ -138,6 +140,9 @@ PlasmoidItem {
     }
 
     function performActiveWindowAction(windowOperation) {
+        if (blocksInactiveWindowActions)
+            return;
+
         if (windowOperation === AppletDecoration.Types.ActionClose)
             windowInfoLoader.item.toggleClose();
         else if (windowOperation === AppletDecoration.Types.ToggleMaximize)
@@ -148,6 +153,19 @@ PlasmoidItem {
             windowInfoLoader.item.togglePinToAllDesktops();
         else if (windowOperation === AppletDecoration.Types.ToggleKeepAbove)
             windowInfoLoader.item.toggleKeepAbove();
+    }
+
+    function slideAnimationEasingType() {
+        if (slideAnimationAcceleration <= 0)
+            return Easing.Linear;
+        if (slideAnimationAcceleration === 1)
+            return Easing.InQuad;
+        if (slideAnimationAcceleration === 2)
+            return Easing.InCubic;
+        if (slideAnimationAcceleration === 3)
+            return Easing.InQuart;
+
+        return Easing.InQuint;
     }
 
     clip: true
@@ -170,6 +188,7 @@ PlasmoidItem {
         return PlasmaCore.Types.ActiveStatus;
     }
     onButtonsStrChanged: initButtons()
+    onLastActiveTaskItemChanged: initButtons()
     Component.onCompleted: {
         if (plasmoid.configuration.buttons.indexOf("9") === -1)
             plasmoid.configuration.buttons = plasmoid.configuration.buttons.concat("|9");
@@ -315,7 +334,11 @@ PlasmoidItem {
             isActive: {
                 //!   FIXME-TEST PERIOD: Disabled because it shows an error from c++ theme when its value is changed
                 //!   and breaks in some cases the buttons coloring through the schemeFile
-                if (root.inactiveStateEnabled && !root.existsWindowActive)
+                // Per-screen: when perScreenActive is on and a local window is shown,
+                // keep buttons bright even if global focus moved to another screen.
+                var perScreenLocalContext = root.perScreenActive && root.existsWindowShown;
+
+                if (root.blocksInactiveWindowActions || (!perScreenLocalContext && root.inactiveStateEnabled && root.existsWindowShown && !root.isLastActiveWindowActive && !root.dimsInactiveWindowActions))
                     return false;
 
                 return true;
@@ -325,7 +348,8 @@ PlasmoidItem {
             isKeepAbove: root.isLastActiveWindowKeepAbove
             localX: x
             localY: y
-            opacity: isVisible ? 1 : 0
+            enabled: !root.blocksInactiveWindowActions
+            opacity: isVisible ? (root.dimsInactiveWindowActions ? root.inactiveDimOpacity : 1) : 0
             visible: (isVisible && !root.isEmptySpaceEnabled) || root.isEmptySpaceEnabled
             onClicked: {
                 root.performActiveWindowAction(windowOperation);
@@ -384,7 +408,11 @@ PlasmoidItem {
             isActive: {
                 //!   FIXME-TEST PERIOD: Disabled because it shows an error from c++ theme when its value is changed
                 //!   and breaks in some cases the buttons coloring through the schemeFile
-                if (root.inactiveStateEnabled && !root.existsWindowActive)
+                // Per-screen: when perScreenActive is on and a local window is shown,
+                // keep buttons bright even if global focus moved to another screen.
+                var perScreenLocalContext = root.perScreenActive && root.existsWindowShown;
+
+                if (root.blocksInactiveWindowActions || (!perScreenLocalContext && root.inactiveStateEnabled && root.existsWindowShown && !root.isLastActiveWindowActive && !root.dimsInactiveWindowActions))
                     return false;
 
                 return true;
@@ -396,7 +424,8 @@ PlasmoidItem {
             auroraeTheme: auroraeThemeEngine
             monochromeIconsEnabled: auroraeThemeEngine.hasMonochromeIcons
             monochromeIconsColor: "transparent"
-            opacity: isVisible ? 1 : 0
+            enabled: !root.blocksInactiveWindowActions
+            opacity: isVisible ? (root.dimsInactiveWindowActions ? root.inactiveDimOpacity : 1) : 0
             visible: (isVisible && !root.isEmptySpaceEnabled) || root.isEmptySpaceEnabled
             onClicked: {
                 root.performActiveWindowAction(windowOperation);
@@ -422,8 +451,8 @@ PlasmoidItem {
         enabled: slideAnimationEnabled && plasmoid.formFactor === PlasmaCore.Types.Horizontal
 
         NumberAnimation {
-            duration: 250
-            easing.type: Easing.InCubic
+            duration: root.slideAnimationDuration
+            easing.type: root.slideAnimationEasingType()
         }
 
     }
@@ -432,8 +461,8 @@ PlasmoidItem {
         enabled: slideAnimationEnabled && plasmoid.formFactor === PlasmaCore.Types.Vertical
 
         NumberAnimation {
-            duration: 250
-            easing.type: Easing.InCubic
+            duration: root.slideAnimationDuration
+            easing.type: root.slideAnimationEasingType()
         }
 
     }

--- a/package/metadata.desktop
+++ b/package/metadata.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Window Buttons
-Comment=Window buttons for your panels
+Comment=Window buttons for Plasma 6 panels with maximized-window titlebar semantics
 
 Encoding=UTF-8
 Icon=focus-windows
@@ -15,7 +15,6 @@ X-KDE-PluginInfo-Category=Windows and Tasks
 X-KDE-PluginInfo-Email=mvourlakos@gmail.com
 X-KDE-PluginInfo-License=GPLv2
 X-KDE-PluginInfo-Name=org.kde.windowbuttons
-X-KDE-PluginInfo-Version=0.11.1
-X-KDE-PluginInfo-Website=https://github.com/psifidotos/applet-window-buttons
+X-KDE-PluginInfo-Version=0.12.0
+X-KDE-PluginInfo-Website=https://github.com/moodyhunter/applet-window-buttons6
 X-KDE-ServiceTypes=Plasma/Applet
-

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -8,16 +8,16 @@
             }
         ],
         "Category": "Windows and Tasks",
-        "Description": "Window buttons for your panels",
+        "Description": "Window buttons for Plasma 6 panels with maximized-window titlebar semantics",
         "Icon": "focus-windows",
         "Id": "org.kde.windowbuttons",
         "License": "GPLv2",
         "Name": "Window Buttons",
-        "Version": "0.11.1",
-        "Website": "https://github.com/psifidotos/applet-window-buttons"
+        "Version": "0.12.0",
+        "Website": "https://github.com/moodyhunter/applet-window-buttons6"
     },
     "Keywords": "window buttons",
     "X-Plasma-API": "declarativeappletscript",
     "X-Plasma-MainScript": "ui/main.qml",
-    "X-Plasma-API-Minimum-Version": "6.0"
+    "X-Plasma-API-Minimum-Version": "6.4"
 }

--- a/tests/windowbuttons_state_contract.test.js
+++ b/tests/windowbuttons_state_contract.test.js
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const mainQml = fs.readFileSync(path.join(repoRoot, 'package/contents/ui/main.qml'), 'utf8');
+const tasksQml = fs.readFileSync(path.join(repoRoot, 'package/contents/ui/PlasmaTasksModel.qml'), 'utf8');
+
+function boolProperty(source, name) {
+  const match = source.match(new RegExp(`readonly property bool ${name}:\\s*([^\\n]+)`));
+  assert.ok(match, `missing readonly property bool ${name}`);
+  return match[1].trim();
+}
+
+// --- PlasmaTasksModel.qml contract ---
+
+const focusExpr = boolProperty(tasksQml, 'focusOutsideTaskModel');
+assert.match(
+  focusExpr,
+  /!targetTaskItem/,
+  'cross-screen focus must not count as outside/unusable while this screen still has a local action target'
+);
+
+assert.match(
+  tasksQml,
+  /readonly property bool hasNoBorder:\s*HasNoBorder === true/,
+  'task delegates must expose Plasma 6.4 HasNoBorder as hasNoBorder'
+);
+assert.match(
+  tasksQml,
+  /onHasNoBorderChanged:\s*plasmaTasksItem\.updateWindowState\(\)/,
+  'titlebar toggles must immediately recompute the represented target'
+);
+assert.match(
+  tasksQml,
+  /function borderlessTaskItem\(maximizedOnly\)/,
+  'target selection must have a borderless-window selector'
+);
+assert.match(
+  tasksQml,
+  /activeTaskItem\.hasNoBorder[\s\S]*borderlessTaskItem\(true\)[\s\S]*if \(lastBorderlessTaskItem\)/,
+  'target priority must be active borderless, then maximized borderless, then best shown borderless'
+);
+
+// --- main.qml contract ---
+
+const blocksExpr = boolProperty(mainQml, 'blocksInactiveWindowActions');
+assert.doesNotMatch(
+  blocksExpr,
+  /existsMaximizedWindow/,
+  'blocking must be based on local target availability, not a broad maximized-window shortcut'
+);
+
+const dimsExpr = boolProperty(mainQml, 'dimsInactiveWindowActions');
+assert.doesNotMatch(
+  dimsExpr,
+  /activeFloatingWithoutMaximizedTarget/,
+  'a same-screen active floating target should not self-dim; dim only when another local active window obscures the tracked target'
+);
+
+assert.match(
+  mainQml,
+  /readonly property bool isLastActiveWindowBorderless:/,
+  'main.qml must expose the represented target titlebar state'
+);
+assert.match(
+  mainQml,
+  /if \(!lastActiveTaskItem \|\| !existsWindowShown \|\| !isLastActiveWindowBorderless\)\s*return true;/,
+  'all non-AlwaysVisible modes must hide unless the represented target is borderless'
+);
+
+// isActive expressions must guard the inactive-gray path with perScreenLocalContext
+const isActiveMatches = mainQml.match(/isActive:\s*\{[^}]*perScreenLocalContext[^}]*\}/g);
+assert.ok(isActiveMatches && isActiveMatches.length >= 2,
+  'both button delegates (pluginButton + auroraeButton) must guard isActive with perScreenLocalContext');
+assert.match(
+  mainQml,
+  /var perScreenLocalContext = root\.perScreenActive && root\.existsWindowShown/,
+  'perScreenLocalContext must be perScreenActive && existsWindowShown'
+);
+
+// --- State model ---
+
+function desiredState({ inactiveStateEnabled, perScreenActive, hasTrackedWindow, hasActiveTask, hasTargetTaskItem, existsWindowShown, targetObscuredByTrackedWindow }) {
+  const focusOutsideTaskModel = hasTrackedWindow && !hasActiveTask && !hasTargetTaskItem;
+  const blocksInactiveWindowActions = inactiveStateEnabled && focusOutsideTaskModel;
+  const dimsInactiveWindowActions = inactiveStateEnabled && targetObscuredByTrackedWindow;
+  const perScreenLocalContext = perScreenActive && existsWindowShown;
+  const isLastActiveWindowActive = hasActiveTask;
+  const buttonIsGray = blocksInactiveWindowActions ||
+    (!perScreenLocalContext && inactiveStateEnabled && existsWindowShown && !isLastActiveWindowActive && !dimsInactiveWindowActions);
+  return {
+    focusOutsideTaskModel,
+    blocksInactiveWindowActions,
+    dimsInactiveWindowActions,
+    buttonIsGray,
+  };
+}
+
+function bestTask(tasks, predicate) {
+  return tasks.filter(task => !task.isMinimized && predicate(task)).sort((a, b) =>
+    b.lastActivated - a.lastActivated || b.stackingOrder - a.stackingOrder)[0] || null;
+}
+
+function desiredTarget(tasks) {
+  const active = tasks.find(task => task.isActive) || null;
+  const shown = bestTask(tasks, () => true);
+  const maximized = bestTask(tasks, task => task.isMaximized);
+  const borderlessMaximized = bestTask(tasks, task => task.hasNoBorder && task.isMaximized);
+  const borderless = bestTask(tasks, task => task.hasNoBorder);
+
+  if (active && active.hasNoBorder && !active.isMinimized)
+    return active;
+  if (borderlessMaximized)
+    return borderlessMaximized;
+  if (borderless)
+    return borderless;
+  if (active && active.isMaximized && !active.isMinimized)
+    return active;
+  return maximized || active || shown;
+}
+
+function desiredMustHide({ alwaysVisible, editMode, target }) {
+  if (alwaysVisible || editMode)
+    return false;
+  return !target || !target.hasNoBorder;
+}
+
+const titledFloating = { id: 'titled-floating', hasNoBorder: false, isMaximized: false, isMinimized: false, isActive: true, lastActivated: 40, stackingOrder: 40 };
+const borderlessFloating = { id: 'borderless-floating', hasNoBorder: true, isMaximized: false, isMinimized: false, isActive: true, lastActivated: 50, stackingOrder: 50 };
+const borderlessTiled = { id: 'borderless-tiled', hasNoBorder: true, isMaximized: false, isMinimized: false, isActive: true, lastActivated: 60, stackingOrder: 60 };
+const borderlessMaximized = { id: 'borderless-maximized', hasNoBorder: true, isMaximized: true, isMinimized: false, isActive: false, lastActivated: 30, stackingOrder: 30 };
+const titledMaximized = { id: 'titled-maximized', hasNoBorder: false, isMaximized: true, isMinimized: false, isActive: true, lastActivated: 70, stackingOrder: 70 };
+
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: desiredTarget([borderlessFloating]) }), false,
+  'borderless floating target shows panel buttons');
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: desiredTarget([borderlessTiled]) }), false,
+  'borderless tiled target shows panel buttons');
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: desiredTarget([borderlessMaximized]) }), false,
+  'borderless maximized target shows panel buttons');
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: desiredTarget([titledMaximized]) }), true,
+  'enabling the native titlebar on a maximized target hides panel buttons');
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: desiredTarget([titledFloating]) }), true,
+  'a titled floating target does not duplicate controls in the panel');
+assert.equal(desiredTarget([borderlessMaximized, titledFloating]).id, 'borderless-maximized',
+  'borderless maximized target stays represented behind an active titled floating window');
+assert.equal(desiredTarget([titledMaximized, { ...borderlessFloating, isActive: false }]).id, 'borderless-floating',
+  'a shown borderless floating window outranks a titled maximized target');
+assert.equal(desiredMustHide({ alwaysVisible: true, editMode: false, target: titledMaximized }), false,
+  'AlwaysVisible explicitly overrides titlebar-aware hiding');
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: true, target: titledMaximized }), false,
+  'edit mode explicitly overrides titlebar-aware hiding');
+
+const titlebarToggleTarget = { ...borderlessMaximized };
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: titlebarToggleTarget }), false,
+  'maximized target starts visible while borderless');
+titlebarToggleTarget.hasNoBorder = false;
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: titlebarToggleTarget }), true,
+  'enabling the native titlebar immediately flips the same target to hidden');
+titlebarToggleTarget.hasNoBorder = true;
+assert.equal(desiredMustHide({ alwaysVisible: false, editMode: false, target: titlebarToggleTarget }), false,
+  'disabling the native titlebar immediately flips the same target back to visible');
+
+// Per-screen: maximized local target stays bright when focus moves to another screen
+assert.deepEqual(desiredState({
+  inactiveStateEnabled: true,
+  perScreenActive: true,
+  hasTrackedWindow: true,
+  hasActiveTask: false,
+  hasTargetTaskItem: true,
+  existsWindowShown: true,
+  targetObscuredByTrackedWindow: false,
+}), {
+  focusOutsideTaskModel: false,
+  blocksInactiveWindowActions: false,
+  dimsInactiveWindowActions: false,
+  buttonIsGray: false,
+}, 'per-screen: local target stays bright under cross-screen focus');
+
+// Same-screen: floating-over-target dims without blocking
+assert.deepEqual(desiredState({
+  inactiveStateEnabled: true,
+  perScreenActive: true,
+  hasTrackedWindow: true,
+  hasActiveTask: true,
+  hasTargetTaskItem: true,
+  existsWindowShown: true,
+  targetObscuredByTrackedWindow: true,
+}), {
+  focusOutsideTaskModel: false,
+  blocksInactiveWindowActions: false,
+  dimsInactiveWindowActions: true,
+  buttonIsGray: false,
+}, 'same-screen floating-over-target dims without blocking');
+
+// No local target: remains blocked/gray
+assert.deepEqual(desiredState({
+  inactiveStateEnabled: true,
+  perScreenActive: true,
+  hasTrackedWindow: true,
+  hasActiveTask: false,
+  hasTargetTaskItem: false,
+  existsWindowShown: false,
+  targetObscuredByTrackedWindow: false,
+}), {
+  focusOutsideTaskModel: true,
+  blocksInactiveWindowActions: true,
+  dimsInactiveWindowActions: false,
+  buttonIsGray: true,
+}, 'no local target remains blocked');
+
+// perScreenActive off: standard inactive gray behavior preserved
+assert.deepEqual(desiredState({
+  inactiveStateEnabled: true,
+  perScreenActive: false,
+  hasTrackedWindow: true,
+  hasActiveTask: false,
+  hasTargetTaskItem: true,
+  existsWindowShown: true,
+  targetObscuredByTrackedWindow: false,
+}), {
+  focusOutsideTaskModel: false,
+  blocksInactiveWindowActions: false,
+  dimsInactiveWindowActions: false,
+  buttonIsGray: true,
+}, 'perScreenActive off: standard inactive gray behavior preserved');
+
+console.log('windowbuttons state contract ok');


### PR DESCRIPTION
## Summary

This updates the applet's window model so panel controls follow the window they visually represent instead of blindly following global focus. It also modernizes the KDecoration3 bridge and adds configurable slide timing.

## Window behavior

- Show panel controls for borderless floating, tiled, and maximized windows, and hide them when the represented window has a native titlebar.
- React immediately to KWin's `HasNoBorder` changes, including titlebar toggles.
- Prefer the active borderless window, then a maximized borderless window, then the most recently activated borderless window.
- Keep a screen-local maximized target represented when a titled floating helper or dialog takes focus above it.
- Bind close, maximize, minimize, keep-above, and inactive-state behavior to the represented target.
- Add a real `MaximizedWindowExists` visibility mode while preserving the existing mode value as a compatibility alias.
- Keep per-screen targets visually active when focus moves to another screen; dim tracked obscured targets and block actions only when focus is outside the task model.

## Native bridge and UI

- Use current Qt 6 input-event constructors while preserving local KDecoration coordinates and the originating pointer device.
- Repaint buttons on full-decoration damage and recreate them when the represented target changes, keeping Breeze maximize/restore state current.
- Tighten decoration metadata validation and bridge signal cleanup.
- Build as C++20 against Plasma 6.4+ and KDecoration3 6.3+.
- Add optional slide duration and acceleration controls while retaining the existing animation defaults.
- Refresh Plasma 6 build instructions, metadata, and changelog entries.

## Testing

- `node tests/windowbuttons_state_contract.test.js`
- `qmlformat -n` for every modified QML file
- Release CMake configure and build
- `ctest --test-dir build-pr --output-on-failure` (1/1 passed)
- `git diff --check`
