### PR TITLE
Add option to minimize the topmost maximized window

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -46,6 +46,10 @@ SPDX-License-Identifier: GPL-2.0-or-later
       <default>false</default>
       <label>Per-screen active window</label>
     </entry>
+    <entry name="minimizeTopmostMaximizedWindow" type="Bool">
+      <default>false</default>
+      <label>Minimize the topmost maximized window</label>
+    </entry>
     <entry name="hiddenState" type="Enum">
       <choices>
         <choice name="SlideOut" />

--- a/package/contents/ui/PlasmaTasksModel.qml
+++ b/package/contents/ui/PlasmaTasksModel.qml
@@ -16,6 +16,7 @@ Item {
     id: plasmaTasksItem
 
     property bool filterByScreen: true
+    readonly property var taskRoles: TaskManager.AbstractTasksModel
     readonly property bool existsWindowActive: lastActiveTaskItem && tasksRepeater.count > 0 && (root.perScreenActive || lastActiveTaskItem.isActive)
     readonly property bool existsWindowShown: lastActiveTaskItem && tasksRepeater.count > 0 && !lastActiveTaskItem.isMinimized
     property Item lastActiveTaskItem: null
@@ -27,8 +28,36 @@ Item {
     }
 
     function toggleMinimized() {
-        if (lastActiveTaskItem)
-            lastActiveTaskItem.toggleMinimized();
+        if (!plasmoid.configuration.minimizeTopmostMaximizedWindow) {
+            if (lastActiveTaskItem)
+                lastActiveTaskItem.toggleMinimized();
+
+            return;
+        }
+
+        var target = null;
+        var highestStackingOrder = -1;
+
+        for (var i = 0; i < tasksModel.count; ++i) {
+            var taskIndex = tasksModel.index(i, 0);
+
+            if (!tasksModel.data(taskIndex, taskRoles.IsWindow)
+                    || !tasksModel.data(taskIndex, taskRoles.IsMaximized)
+                    || !tasksModel.data(taskIndex, taskRoles.IsMinimizable)
+                    || tasksModel.data(taskIndex, taskRoles.IsMinimized)
+                    || tasksModel.data(taskIndex, taskRoles.IsHidden)) {
+                continue;
+            }
+
+            var stackingOrder = tasksModel.data(taskIndex, taskRoles.StackingOrder);
+            if (stackingOrder > highestStackingOrder) {
+                highestStackingOrder = stackingOrder;
+                target = taskIndex;
+            }
+        }
+
+        if (target)
+            tasksModel.requestToggleMinimized(target);
 
     }
 

--- a/package/contents/ui/config/ConfigBehavior.qml
+++ b/package/contents/ui/config/ConfigBehavior.qml
@@ -19,6 +19,7 @@ KCM.SimpleKCM {
     property alias cfg_hiddenState: root.hiddenState
     property alias cfg_perScreenActive: perScreenActiveChk.checked
     property alias cfg_filterByScreen: filterByScreenChk.checked
+    property alias cfg_minimizeTopmostMaximizedWindow: minimizeTopmostMaximizedWindowChk.checked
     property alias cfg_inactiveStateEnabled: inactiveChk.checked
     property alias cfg_borderlessMaximizedWindows: root.borderlessMaximizedWindows
 
@@ -145,6 +146,11 @@ KCM.SimpleKCM {
         QQC2.CheckBox {
             id: perScreenActiveChk
             text: i18n("Per-screen active window:")
+        }
+
+        QQC2.CheckBox {
+            id: minimizeTopmostMaximizedWindowChk
+            text: i18n("Minimize the topmost maximized window")
         }
 
         Item {


### PR DESCRIPTION
Add an optional, disabled-by-default setting to make the minimize button target the topmost maximized window.

When multiple maximized windows and other windows overlap, the applet currently minimizes the last active window, which may not be the maximized window on top. With this option enabled, it minimizes the topmost visible, minimizable maximized window; if none exists, it does nothing. For example, by default, clicking the minimize button in the upper right corner will minimize Konsole, and when this option enabled, Kate will be minimized.

<img width="1920" height="1080" alt="屏幕截图_20260807_201259" src="https://github.com/user-attachments/assets/cff3a1d7-4181-4a8e-b4a7-eef004e4e317" />
